### PR TITLE
Use colmena from flake.lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
           extraPullNames: xfix-pw-production
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - run: nix-shell -p colmena --run 'colmena build'
+      - run: nix run --extra-experimental-features 'nix-command flakes' .#colmena build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - run: echo User github-actions > ~/.ssh/config
-      - run: nix-shell -p colmena --run 'colmena apply'
+      - run: nix run --extra-experimental-features 'nix-command flakes' .#colmena apply

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,10 @@
         ];
       };
     };
+    apps.x86_64-linux.colmena = {
+      type = "app";
+      program = "${nixpkgs.legacyPackages.x86_64-linux.colmena}/bin/colmena";
+    };
     formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
   };
 }


### PR DESCRIPTION
This avoids having to download libraries from nixos-unstable just for colmena and ensures stability of GitHub Workflows tasks (other than ubuntu-latest reference which is impure, but not much can be done with that).