### PR TITLE
Avoid building pastebin.run's JavaScript within IFD context

### DIFF
--- a/pkgs/pastebinrun/default.nix
+++ b/pkgs/pastebinrun/default.nix
@@ -30,6 +30,7 @@
       name = "src";
       paths = [client-js src];
     };
+    root = src;
     nativeBuildInputs = [pkgconfig];
     buildInputs = [openssl postgresql_14.lib];
     doCheck = true;


### PR DESCRIPTION
Not building JavaScript part of application speed ups evaluation.